### PR TITLE
fix(pdfjs): enable ImageDecoder support for PDF previews

### DIFF
--- a/share/src/main/webapp/components/preview/PdfJs.js
+++ b/share/src/main/webapp/components/preview/PdfJs.js
@@ -859,6 +859,9 @@
             params.disableRange = true;
          }
 
+         // Allow pdf.js to use ImageDecoder in the worker for image conversion/rendering performance.
+         params.isImageDecoderSupported = true;
+
          if (Alfresco.logger.isDebugEnabled())
          {
             Alfresco.logger.debug("Using params.disableRange=" + params.disableRange + " params.disableAutoFetch:" + params.disableAutoFetch);


### PR DESCRIPTION
This updates the Alfresco Share PDF.js wrapper to pass the official Mozilla/pdf.js `isImageDecoderSupported` DocumentInitParameters option into `pdfjsLib.getDocument(params)`.

The option allows pdf.js to use `ImageDecoder` in the worker for image conversion/rendering performance where supported. Without this parameter, affected PDFs with embedded JPEG images can take a much slower decoding/rendering path in Share preview.

We verified the behavior in an Alfresco Share 25.2.0 based runtime with the same PDF and browser:
- without the parameter, the affected PDF preview loaded very slowly;
- with the parameter enabled, the same PDF loaded instantly.

The slow path is especially noticeable in shared Citrix environments, where affected PDFs can take around half a minute to load.